### PR TITLE
Correctly yield matched name from FindMusicFiles

### DIFF
--- a/LibRPMedia-1.0.lua
+++ b/LibRPMedia-1.0.lua
@@ -371,9 +371,11 @@ function IterMatchingMusicFiles(music, search)
             if not seen[musicIndex] then
                 seen[musicIndex] = true;
 
+                -- It's important that we yield the matched name and not
+                -- the canonical name, since the searches don't make sense
+                -- otherwise.
                 local musicFile = data.file[musicIndex];
-                local musicName = data.name[musicIndex];
-                return musicIndex, musicFile, musicName;
+                return musicIndex, musicFile, name;
             end
         end
     end


### PR DESCRIPTION
Previously we accidentally returned the canonical name, which meant searches would sometimes return nonsensical results. For example, searching for `mus_82` could return names with `mus_735` that were also part of 8.2 sound kits.