### PR TITLE
Code cleanup (post 1.0)

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -16,6 +16,10 @@ externals:
         tag: latest
 
 ignore:
-    - Config
-    - Exporter
+    - Libs/LibDeflate/.appveyor
+    - Libs/LibDeflate/.rockspecs
+    - Libs/LibDeflate/.travis
+    - Libs/LibDeflate/docs
+    - Libs/LibDeflate/examples
+    - Libs/LibDeflate/tests
     - Makefile

--- a/LibRPMedia-1.0.lua
+++ b/LibRPMedia-1.0.lua
@@ -174,7 +174,7 @@ function LibRPMedia:FindMusicFiles(musicName, options)
 
     -- If the search space is empty then everything matches; the iterator
     -- from FindAllMusic files is *considerably* more efficient.
-    if not musicName or musicName == "" then
+    if musicName == "" then
         return self:FindAllMusicFiles();
     end
 
@@ -362,7 +362,6 @@ do
         local b64bytes = b64bytes; -- luacheck: no redefined
         local strbyte = strbyte; -- luacheck: no redefined
         local strchar = strchar; -- luacheck: no redefined
-        local strjoin = strjoin; -- luacheck: no redefined
 
         -- Read the text in blocks of 4 bytes.
         for i = 1, #text, 4 do
@@ -394,9 +393,9 @@ do
             -- Put the three output bytes into the output table.
             n = n + 1;
             if nilNum == 0 then
-                t[n] = strjoin("", strchar(a), strchar(b), strchar(c));
+                t[n] = strchar(a, b, c);
             elseif nilNum == 1 then
-                t[n] = strjoin("", strchar(a), strchar(b));
+                t[n] = strchar(a, b);
             elseif nilNum == 2 then
                 t[n] = strchar(a);
             end


### PR DESCRIPTION
The type assertion change removes the need to support a nil parameter to FindMusicFiles, so we'll remove that test.

For compressed data, string.char can accept multiple arguments and will return a joined string automatically in that case.