### PR TITLE
Strip LibDeflate directories from packager

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -16,6 +16,10 @@ externals:
         tag: latest
 
 ignore:
-    - Config
-    - Exporter
+    - Libs/LibDeflate/.appveyor
+    - Libs/LibDeflate/.rockspecs
+    - Libs/LibDeflate/.travis
+    - Libs/LibDeflate/docs
+    - Libs/LibDeflate/examples
+    - Libs/LibDeflate/tests
     - Makefile


### PR DESCRIPTION
Applying this one to master before tagging as v1.0.0 as it's kinda important, and doesn't change any other aspects of the library.