### PR TITLE
Change load behaviour to always pull in embeds

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -6,12 +6,13 @@ license-output: LICENSE
 
 externals:
     Libs/LibStub:
-        url: svn://svn.wowace.com/wow/libstub/mainline/trunk
+        url: https://repos.wowace.com/wow/libstub/trunk
         tag: latest
 
 ignore:
     - Exporter
     - Libs/LibStub/tests
+    - Libs/LibStub/LibStub.toc
     - Makefile
     - Tests
     - UI

--- a/Embeds.xml
+++ b/Embeds.xml
@@ -2,8 +2,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
 
-    <Include file="Embeds.xml"/>
-
-    <Script file="LibRPMedia-1.0.lua"/>
-    <Script file="LibRPMedia-Classic-1.0.lua"/>
+    <Script file="Libs\LibStub\LibStub.lua"/>
 </Ui>

--- a/LibRPMedia-1.0.toc
+++ b/LibRPMedia-1.0.toc
@@ -10,8 +10,6 @@
 ## X-Curse-Project-ID: 324111
 ## X-WoWI-ID: 25019
 
-Libs\LibStub\LibStub.lua
-
 LibRPMedia-1.0.xml
 #@do-not-package@
 Tests\Tests.xml

--- a/LibRPMedia-1.0.xml
+++ b/LibRPMedia-1.0.xml
@@ -1,6 +1,8 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/..\FrameXML\UI.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
+
+    <Include file="Embeds.xml"/>
 
     <Script file="LibRPMedia-1.0.lua"/>
     <Script file="LibRPMedia-Classic-1.0.lua"/>

--- a/LibRPMedia-Retail-1.0.xml
+++ b/LibRPMedia-Retail-1.0.xml
@@ -1,6 +1,8 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/..\FrameXML\UI.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
+
+    <Include file="Embeds.xml"/>
 
     <Script file="LibRPMedia-1.0.lua"/>
     <Script file="LibRPMedia-Retail-1.0.lua"/>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `LibRPMedia-1.0.xml` file includes all references to databases for both Reta
 
 ### Dependencies
 
-This library depends upon the following. These must be loaded *prior* to loading LibRPMedia via any of its XML files; the library will not load its embedded dependencies automatically.
+This library depends upon the following. These libraries are loaded automatically when including any of the above XML files.
 
  * [LibStub](https://www.curseforge.com/wow/addons/libstub)
 


### PR DESCRIPTION
The documented behaviour for embedded dependencies was that the addon pulling in the library should manually load them so that our dependencies can be omitted in packaged builds.

However this can prove somewhat inconvenient and a bit of a trap since the "expected" behaviour is that pulling in the library should generally just work.

Not sure if I want to go through with this change at the moment, so this is targeting the next branch.