### PR TITLE
Prefer use of CallMethodOnNearestAncestor

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -56,6 +56,7 @@ stds.wow = {
     read_globals = {
         "CallbackRegistryBaseMixin",
         "CallErrorHandler",
+        "CallMethodOnNearestAncestor",
         "Clamp",
         "ColumnDisplayMixin",
         "CreateFramePool",

--- a/UI/Browser.lua
+++ b/UI/Browser.lua
@@ -143,9 +143,9 @@ function LibRPMedia_SearchOptionsDropDownMixin:Initialize(level)
     local info = UIDropDownMenu_CreateInfo();
 
     -- Search methods.
-    local method = self:GetParent():GetSearchMethod();
+    local _, method = CallMethodOnNearestAncestor(self, "GetSearchMethod");
     local methodSetter = function(item)
-        self:GetParent():SetSearchMethod(item.value);
+        CallMethodOnNearestAncestor(self, "SetSearchMethod", item.value);
     end
 
     info.hasArrow = false;
@@ -463,7 +463,7 @@ function LibRPMedia_MusicColumnDisplayMixin:OnLoad()
     ColumnDisplayMixin.OnLoad(self);
 
     self.sortingFunction = function(_, columnIndex)
-        self:GetParent():SortByColumnIndex(columnIndex);
+        CallMethodOnNearestAncestor(self, "SortByColumnIndex", columnIndex);
     end
 
     self:LayoutColumns({
@@ -817,9 +817,7 @@ function LibRPMedia_BrowserTabMixin:OnLoad()
 end
 
 function LibRPMedia_BrowserTabMixin:OnClick()
-    local browserFrame = self:GetParent();
-
-    browserFrame:SetTab(self:GetID());
+    CallMethodOnNearestAncestor(self, "SetTab", self:GetID());
     PlaySound(SOUNDKIT.UI_TOYBOX_TABS);
 end
 

--- a/UI/Browser.xml
+++ b/UI/Browser.xml
@@ -1,6 +1,6 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.blizzard.com/wow/ui/..\FrameXML\UI.xsd">
+    xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
 
     <Script file="Browser.lua"/>
 
@@ -29,9 +29,9 @@
                 <Scripts>
                     <OnClick>
                         if not IsShiftKeyDown() then
-                            self:GetParent():PreviousPage();
+                            CallMethodOnNearestAncestor(self, "PreviousPage");
                         else
-                            self:GetParent():AdvancePage(-10);
+                            CallMethodOnNearestAncestor(self, "AdvancePage", -10);
                         end
 
                         PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -50,9 +50,9 @@
                 <Scripts>
                     <OnClick>
                         if not IsShiftKeyDown() then
-                            self:GetParent():NextPage();
+                            CallMethodOnNearestAncestor(self, "NextPage");
                         else
-                            self:GetParent():AdvancePage(10);
+                            CallMethodOnNearestAncestor(self, "AdvancePage", 10);
                         end
 
                         PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON);
@@ -95,7 +95,7 @@
                 </Anchors>
                 <Scripts>
                     <OnTextChanged inherit="prepend">
-                        self:GetParent():UpdateVisualization();
+                        CallMethodOnNearestAncestor(self, "UpdateVisualization");
                     </OnTextChanged>
                 </Scripts>
             </EditBox>
@@ -223,7 +223,7 @@
                 </Anchors>
                 <Scripts>
                     <OnTextChanged inherit="prepend">
-                        self:GetParent():UpdateVisualization();
+                        CallMethodOnNearestAncestor(self, "UpdateVisualization");
                     </OnTextChanged>
                 </Scripts>
             </EditBox>


### PR DESCRIPTION
This makes things a bit less brittle if frame ownership ever needs juggling around.

This isn't important for now and can safely be deferred for next.