### PR TITLE
Fix uses of CallbackRegistryMixin

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -54,7 +54,7 @@ stds.libstub = {
 
 stds.wow = {
     read_globals = {
-        "CallbackRegistryBaseMixin",
+        "CallbackRegistryMixin",
         "CallErrorHandler",
         "CallMethodOnNearestAncestor",
         "Clamp",

--- a/UI/Browser.lua
+++ b/UI/Browser.lua
@@ -39,10 +39,13 @@ local function SafeIterator(source, ...)
 end
 
 --- Mixin that allows pagination of content via a bar with page buttons.
-LibRPMedia_PaginationBarMixin = CreateFromMixins(CallbackRegistryBaseMixin);
+LibRPMedia_PaginationBarMixin = CreateFromMixins(CallbackRegistryMixin);
+LibRPMedia_PaginationBarMixin:GenerateCallbackEvents({
+    "OnPageChanged",
+});
 
 function LibRPMedia_PaginationBarMixin:OnLoad()
-    CallbackRegistryBaseMixin.OnLoad(self);
+    CallbackRegistryMixin.OnLoad(self);
 
     -- Initialize with a single page.
     self.pageCount = 1;
@@ -306,7 +309,7 @@ function LibRPMedia_IconContentMixin:OnLoad()
     -- When the page changes, we'll need to update our icons.
     self.PaginationBar:RegisterCallback("OnPageChanged", function()
         self:UpdateIconVisualization();
-    end);
+    end, self);
 
     -- Start by displaying all icons.
     self:SetSearchFilter("");


### PR DESCRIPTION
This was adjusted heavily in 9.0; for now these fixes won't work on Classic but I'm not anticipating _needing_ the browser there for some time at least.